### PR TITLE
Update title of NYT crossword tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _I did not create any of the resources listed below. If you have a special reque
 - [Tools](#tools)
 
 ### Automations
-- [Automatically uploading the daily NYT crossword to my Ratta Supernote](https://nathanbuchar.com/automatically-uploading-the-nyt-crossword-supernote/)
+- [Automatically uploading the daily NYT crossword to a Supernote](https://nathanbuchar.com/automatically-uploading-the-nyt-crossword-supernote/)
 
 ### Pens
 - [How to safely DIY a Supernote Pen](https://www.reddit.com/r/Supernote/comments/lzl3a1/how_to_safely_diy_a_supernote_pen/)


### PR DESCRIPTION
[I updated the title of the webpage](https://nathanbuchar.com/automatically-uploading-the-nyt-crossword-supernote/)