### PR TITLE
Add supernote-pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Please note that most tools need some developer skills to be used.
 - [Supernote local sync app](https://github.com/RohanGautam/supernote-tool): simple terminal app to sync supernote notes to a local directory and convert them to a PDF
 - [Unofficial Python tool for Supernote](https://github.com/jya-dev/supernote-tool): convert Supernote's `*.note` files into PDF, PNG or SVG from the command line
 - [Unofficial Obsidian Plugin](https://github.com/philips/obsidian-plugin-supernote?tab=readme-ov-file#supernote-obsidian-plugin): convert notes dropped into an Obsidian vault to PNG to use in markdown.
+- [Supernote-tool](https://github.com/RohanGautam/supernote_pdf) : a CLI for the fastest way to convert `.note` files (and directories of them) into `.pdf` files. 
 
 ### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Please note that most tools need some developer skills to be used.
 - [Supernote local sync app](https://github.com/RohanGautam/supernote-tool): simple terminal app to sync supernote notes to a local directory and convert them to a PDF
 - [Unofficial Python tool for Supernote](https://github.com/jya-dev/supernote-tool): convert Supernote's `*.note` files into PDF, PNG or SVG from the command line
 - [Unofficial Obsidian Plugin](https://github.com/philips/obsidian-plugin-supernote?tab=readme-ov-file#supernote-obsidian-plugin): convert notes dropped into an Obsidian vault to PNG to use in markdown.
-- [Supernote-tool](https://github.com/RohanGautam/supernote_pdf) : a CLI for the fastest way to convert `.note` files (and directories of them) into `.pdf` files. 
+- [Supernote-pdf](https://github.com/RohanGautam/supernote_pdf) : a CLI for the fastest way to convert `.note` files (and directories of them) into `.pdf` files. 
 
 ### Tutorials
 


### PR DESCRIPTION
Hey! I'm the author of [supernote-pdf](https://github.com/RohanGautam/supernote_pdf), its a library written in rust that uses language features and parallelism for really fast pdf conversion. Would be nice to add it to your list. The 'fastest' claim comes from my comparison to the [unofficial python tool](https://github.com/jya-dev/supernote-tool/tree/master) in the benchmarks section of my repository, where it is orders of magnitude faster for the same task.