### PR TITLE
Add macOS/Docker tools for Apple integration, OCR, and self-hosted cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Please note that most tools need some developer skills to be used.
 - [Python script for desktop note files viewer](https://www.reddit.com/r/Supernote/comments/qrxngb/python_script_for_desktop_note_files_viewer/): generate HTML files so you can easily read your notes in your browser
 - [sncloud](https://github.com/julianprester/sncloud): unofficial Python API client that allows you to access your Supernote files through the Supernote Cloud.
 - [SNEX](https://github.com/mmujynya/snex): Supernote notebook to [Excalidraw](https://excalidraw.com/) file converter
+- [supernote-apple-note-unifier](https://github.com/liketheduck/supernote-apple-note-unifier): mirror Apple Notes to Supernote devices as .note files
+- [supernote-apple-reminders-sync](https://github.com/liketheduck/supernote-apple-reminders-sync): bidirectional sync between Supernote (MariaDB/Docker) and Apple Reminders on macOS
+- [supernote-koreader-harmonizer](https://github.com/liketheduck/supernote-koreader-harmonizer): sync KOReader highlights to Supernote Digest
+- [supernote-ocr-enhancer](https://github.com/liketheduck/supernote-ocr-enhancer): enhance Supernote .note files with Apple Vision Framework OCR for accurate handwriting recognition with word-level bounding boxes
+- [supernote-private-cloud-docker](https://github.com/liketheduck/supernote-private-cloud-docker): self-hosted Supernote Private Cloud with Docker Compose, HTTPS, and email support
 - [supernote-tldraw](https://github.com/cristianvasquez/supernote-tldraw): display `*.note` files in a canvas
 - [supernote-web-viewer](https://github.com/cristianvasquez/supernote-web-viewer): display a `*.note` files in the browser
 - [Supernote local sync app](https://github.com/RohanGautam/supernote-tool): simple terminal app to sync supernote notes to a local directory and convert them to a PDF


### PR DESCRIPTION
## Summary

Adds 5 tools for Supernote integration with the Apple ecosystem and self-hosting:

- **supernote-apple-note-unifier**: Mirror Apple Notes to Supernote as .note files
- **supernote-apple-reminders-sync**: Bidirectional sync with Apple Reminders on macOS
- **supernote-koreader-harmonizer**: Sync KOReader highlights to Supernote Digest
- **supernote-ocr-enhancer**: Local OCR enhancement using Apple Vision Framework (injects OCR back into .note files with word-level bounding boxes)
- **supernote-private-cloud-docker**: Self-hosted Private Cloud replacement with Docker Compose, HTTPS, and email support

All require developer skills, consistent with existing Tools section entries.